### PR TITLE
Adapted tests to work for Mainnet fork

### DIFF
--- a/contracts/mock/MockFallbackCaller.sol
+++ b/contracts/mock/MockFallbackCaller.sol
@@ -1,0 +1,83 @@
+// SPDX-License-Identifier: MIT
+// File: Interfaces/IFallbackCaller.sol
+
+pragma solidity 0.8.17;
+
+interface IFallbackCaller {
+  // --- Events ---
+  event FallbackTimeOutChanged(uint256 _oldTimeOut, uint256 _newTimeOut);
+
+  // --- Function External View ---
+
+  // NOTE: The fallback oracle must always return its answer scaled to 18 decimals where applicable
+  //       The system will assume an 18 decimal response for efficiency.
+  function getFallbackResponse() external view returns (uint256, uint256, bool);
+
+  // NOTE: this returns the timeout window interval for the fallback oracle instead
+  // of storing in the `PriceFeed` contract is retrieve for the `FallbackCaller`
+  function fallbackTimeout() external view returns (uint256);
+
+  // --- Function External Setter ---
+
+  function setFallbackTimeout(uint256 newFallbackTimeout) external;
+}
+// File: contracts/MockFallbackCaller.sol
+
+pragma solidity 0.8.17;
+
+contract MockFallbackCaller is IFallbackCaller {
+  uint256 public _answer;
+  uint256 public _timestampRetrieved;
+  uint256 public _fallbackTimeout = 90000; // NOTE: MAYBE BEST TO CUSTOMIZE
+  bool public _success;
+  uint256 public _initAnswer;
+
+  bool public getFallbackResponseRevert;
+  bool public fallbackTimeoutRevert;
+
+  constructor(uint256 answer) {
+    _initAnswer = answer;
+  }
+
+  function setGetFallbackResponseRevert() external {
+    getFallbackResponseRevert = !getFallbackResponseRevert;
+  }
+
+  function setFallbackTimeoutRevert() external {
+    fallbackTimeoutRevert = !fallbackTimeoutRevert;
+  }
+
+  function setFallbackResponse(
+    uint256 answer,
+    uint256 timestampRetrieved,
+    bool success
+  ) external {
+    _answer = answer;
+    _timestampRetrieved = timestampRetrieved;
+    _success = success;
+  }
+
+  function setFallbackTimeout(uint256 newFallbackTimeout) external {
+    uint256 oldTimeOut = _fallbackTimeout;
+    _fallbackTimeout = newFallbackTimeout;
+    emit FallbackTimeOutChanged(oldTimeOut, newFallbackTimeout);
+  }
+
+  function getFallbackResponse()
+    external
+    view
+    returns (uint256, uint256, bool)
+  {
+    if (getFallbackResponseRevert) {
+      require(1 == 0, "getFallbackResponse reverted");
+    }
+    return (_answer, _timestampRetrieved, _success);
+  }
+
+  function fallbackTimeout() external view returns (uint256) {
+    if (fallbackTimeoutRevert) {
+      require(1 == 0, "fallbackTimeout reverted");
+    }
+    return _fallbackTimeout;
+  }
+}

--- a/contracts/mock/PriceFeedTester.sol
+++ b/contracts/mock/PriceFeedTester.sol
@@ -1,0 +1,367 @@
+// File: contracts/Dependencies/Authority.sol
+
+pragma solidity 0.8.17;
+
+/// @notice A generic interface for a contract which provides authorization data to an Auth instance.
+/// @author Solmate (https://github.com/transmissions11/solmate/blob/main/src/auth/Auth.sol)
+/// @author Modified from Dappsys (https://github.com/dapphub/ds-auth/blob/master/src/auth.sol)
+interface Authority {
+  function canCall(
+    address user,
+    address target,
+    bytes4 functionSig
+  ) external view returns (bool);
+}
+
+// File: contracts/Dependencies/AuthNoOwner.sol
+
+pragma solidity 0.8.17;
+
+/// @notice Provides a flexible and updatable auth pattern which is completely separate from application logic.
+/// @author Modified by BadgerDAO to remove owner
+/// @author Solmate (https://github.com/transmissions11/solmate/blob/main/src/auth/Auth.sol)
+/// @author Modified from Dappsys (https://github.com/dapphub/ds-auth/blob/master/src/auth.sol)
+contract AuthNoOwner {
+  event AuthorityUpdated(address indexed user, Authority indexed newAuthority);
+
+  Authority private _authority;
+  bool private _authorityInitialized;
+
+  modifier requiresAuth() virtual {
+    require(isAuthorized(msg.sender, msg.sig), "Auth: UNAUTHORIZED");
+
+    _;
+  }
+
+  function authority() public view returns (Authority) {
+    return _authority;
+  }
+
+  function authorityInitialized() public view returns (bool) {
+    return _authorityInitialized;
+  }
+
+  function isAuthorized(
+    address user,
+    bytes4 functionSig
+  ) internal view virtual returns (bool) {
+    Authority auth = _authority; // Memoizing authority saves us a warm SLOAD, around 100 gas.
+
+    // Checking if the caller is the owner only after calling the authority saves gas in most cases, but be
+    // aware that this makes protected functions uncallable even to the owner if the authority is out of order.
+    return (address(auth) != address(0) &&
+      auth.canCall(user, address(this), functionSig));
+  }
+
+  function setAuthority(address newAuthority) public virtual {
+    // We check if the caller is the owner first because we want to ensure they can
+    // always swap out the authority even if it's reverting or using up a lot of gas.
+    require(_authority.canCall(msg.sender, address(this), msg.sig));
+
+    _authority = Authority(newAuthority);
+
+    // Once authority is set once via any means, ensure it is initialized
+    if (!_authorityInitialized) {
+      _authorityInitialized = true;
+    }
+
+    emit AuthorityUpdated(msg.sender, Authority(newAuthority));
+  }
+
+  /// @notice Changed constructor to initialize to allow flexiblity of constructor vs initializer use
+  /// @notice sets authorityInitiailzed flag to ensure only one use of
+  function _initializeAuthority(address newAuthority) internal {
+    require(address(_authority) == address(0), "Auth: authority is non-zero");
+    require(!_authorityInitialized, "Auth: authority already initialized");
+
+    _authority = Authority(newAuthority);
+    _authorityInitialized = true;
+
+    emit AuthorityUpdated(address(this), Authority(newAuthority));
+  }
+}
+
+// File: contracts/Dependencies/Context.sol
+
+// OpenZeppelin Contracts v4.4.1 (utils/Context.sol)
+
+pragma solidity 0.8.17;
+
+/**
+ * @dev Provides information about the current execution context, including the
+ * sender of the transaction and its data. While these are generally available
+ * via msg.sender and msg.data, they should not be accessed in such a direct
+ * manner, since when dealing with meta-transactions the account sending and
+ * paying for execution may not be the actual sender (as far as an application
+ * is concerned).
+ *
+ * This contract is only required for intermediate, library-like contracts.
+ */
+abstract contract Context {
+  function _msgSender() internal view virtual returns (address) {
+    return msg.sender;
+  }
+
+  function _msgData() internal view virtual returns (bytes calldata) {
+    return msg.data;
+  }
+}
+
+// File: contracts/Dependencies/Ownable.sol
+
+// OpenZeppelin Contracts (last updated v4.7.0) (access/Ownable.sol)
+
+pragma solidity 0.8.17;
+
+/**
+ * @dev Contract module which provides a basic access control mechanism, where
+ * there is an account (an owner) that can be granted exclusive access to
+ * specific functions.
+ *
+ * By default, the owner account will be the one that deploys the contract. This
+ * can later be changed with {transferOwnership}.
+ *
+ * This module is used through inheritance. It will make available the modifier
+ * `onlyOwner`, which can be applied to your functions to restrict their use to
+ * the owner.
+ */
+abstract contract Ownable is Context {
+  address private _owner;
+
+  event OwnershipTransferred(
+    address indexed previousOwner,
+    address indexed newOwner
+  );
+
+  /**
+   * @dev Initializes the contract setting the deployer as the initial owner.
+   */
+  constructor() {
+    _transferOwnership(_msgSender());
+  }
+
+  /**
+   * @dev Throws if called by any account other than the owner.
+   */
+  modifier onlyOwner() {
+    _checkOwner();
+    _;
+  }
+
+  /**
+   * @dev Returns the address of the current owner.
+   */
+  function owner() public view virtual returns (address) {
+    return _owner;
+  }
+
+  /**
+   * @dev Throws if the sender is not the owner.
+   */
+  function _checkOwner() internal view virtual {
+    require(owner() == _msgSender(), "Ownable: caller is not the owner");
+  }
+
+  /**
+   * @dev Leaves the contract without owner. It will not be possible to call
+   * `onlyOwner` functions anymore. Can only be called by the current owner.
+   *
+   * NOTE: Renouncing ownership will leave the contract without an owner,
+   * thereby removing any functionality that is only available to the owner.
+   */
+  function renounceOwnership() public virtual onlyOwner {
+    _transferOwnership(address(0));
+  }
+
+  /**
+   * @dev Transfers ownership of the contract to a new account (`newOwner`).
+   * Can only be called by the current owner.
+   */
+  function transferOwnership(address newOwner) public virtual onlyOwner {
+    require(newOwner != address(0), "Ownable: new owner is the zero address");
+    _transferOwnership(newOwner);
+  }
+
+  /**
+   * @dev Transfers ownership of the contract to a new account (`newOwner`).
+   * Internal function without access restriction.
+   */
+  function _transferOwnership(address newOwner) internal virtual {
+    address oldOwner = _owner;
+    _owner = newOwner;
+    emit OwnershipTransferred(oldOwner, newOwner);
+  }
+}
+
+// File: contracts/Interfaces/IFallbackCaller.sol
+
+pragma solidity 0.8.17;
+
+interface IFallbackCaller {
+  // --- Events ---
+  event FallbackTimeOutChanged(uint256 _oldTimeOut, uint256 _newTimeOut);
+
+  // --- Function External View ---
+
+  // NOTE: The fallback oracle must always return its answer scaled to 18 decimals where applicable
+  //       The system will assume an 18 decimal response for efficiency.
+  function getFallbackResponse() external view returns (uint256, uint256, bool);
+
+  // NOTE: this returns the timeout window interval for the fallback oracle instead
+  // of storing in the `PriceFeed` contract is retrieve for the `FallbackCaller`
+  function fallbackTimeout() external view returns (uint256);
+
+  // --- Function External Setter ---
+
+  function setFallbackTimeout(uint256 newFallbackTimeout) external;
+}
+
+// File: contracts/Interfaces/IPriceFeed.sol
+
+pragma solidity 0.8.17;
+
+interface IPriceFeed {
+  // --- Events ---
+  event LastGoodPriceUpdated(uint256 _lastGoodPrice);
+  event PriceFeedStatusChanged(Status newStatus);
+  event FallbackCallerChanged(
+    address indexed _oldFallbackCaller,
+    address indexed _newFallbackCaller
+  );
+  event UnhealthyFallbackCaller(
+    address indexed _fallbackCaller,
+    uint256 timestamp
+  );
+
+  // --- Structs ---
+
+  struct ChainlinkResponse {
+    uint80 roundEthBtcId;
+    uint80 roundStEthEthId;
+    uint256 answer;
+    uint256 timestampEthBtc;
+    uint256 timestampStEthEth;
+    bool success;
+  }
+
+  struct FallbackResponse {
+    uint256 answer;
+    uint256 timestamp;
+    bool success;
+  }
+
+  // --- Enum ---
+
+  enum Status {
+    chainlinkWorking,
+    usingFallbackChainlinkUntrusted,
+    bothOraclesUntrusted,
+    usingFallbackChainlinkFrozen,
+    usingChainlinkFallbackUntrusted
+  }
+
+  // --- Function ---
+  function fetchPrice() external returns (uint256);
+}
+
+// File: contracts/TestContracts/testnet/PriceFeedTestnet.sol
+
+pragma solidity 0.8.17;
+
+/*
+ * PriceFeed placeholder for testnet and development. The price can be manually input or fetched from
+   the Fallback's TestNet implementation. Backwards compatible with local test environment as it defaults to use
+   the manual price.
+ */
+contract PriceFeedTestnet is IPriceFeed, Ownable, AuthNoOwner {
+  // --- variables ---
+
+  uint256 private _price = 7428 * 1e13; // stETH/BTC price == ~15.8118 ETH per BTC
+  bool public _useFallback;
+  IFallbackCaller public fallbackCaller; // Wrapper contract that calls the Fallback system
+
+  constructor(address _authorityAddress) {
+    _initializeAuthority(_authorityAddress);
+  }
+
+  // --- Dependency setters ---
+
+  function setAddresses(
+    address _priceAggregatorAddress, // Not used but kept for compatibility with deployment script
+    address _fallbackCallerAddress,
+    address _authorityAddress
+  ) external onlyOwner {
+    fallbackCaller = IFallbackCaller(_fallbackCallerAddress);
+
+    _initializeAuthority(_authorityAddress);
+
+    renounceOwnership();
+  }
+
+  // --- Functions ---
+
+  // View price getter for simplicity in tests
+  function getPrice() external view returns (uint256) {
+    return _price;
+  }
+
+  function fetchPrice() external override returns (uint256) {
+    // Fire an event just like the mainnet version would.
+    // This lets the subgraph rely on events to get the latest price even when developing locally.
+    if (_useFallback) {
+      FallbackResponse memory fallbackResponse = _getCurrentFallbackResponse();
+      if (fallbackResponse.success) {
+        _price = fallbackResponse.answer;
+      }
+    }
+    emit LastGoodPriceUpdated(_price);
+    return _price;
+  }
+
+  // Manual external price setter.
+  function setPrice(uint256 price) external returns (bool) {
+    _price = price;
+    return true;
+  }
+
+  // Manual toggle use of Tellor testnet feed
+  function toggleUseFallback() external returns (bool) {
+    _useFallback = !_useFallback;
+    return _useFallback;
+  }
+
+  function setFallbackCaller(address _fallbackCaller) external requiresAuth {
+    address oldFallbackCaller = address(fallbackCaller);
+    fallbackCaller = IFallbackCaller(_fallbackCaller);
+    emit FallbackCallerChanged(oldFallbackCaller, _fallbackCaller);
+  }
+
+  // --- Oracle response wrapper functions ---
+  /*
+   * "_getCurrentFallbackResponse" fetches stETH/BTC from the Fallback, and returns it as a
+   * FallbackResponse struct.
+   */
+  function _getCurrentFallbackResponse()
+    internal
+    view
+    returns (FallbackResponse memory fallbackResponse)
+  {
+    uint256 stEthBtcValue;
+    uint256 stEthBtcTimestamp;
+    bool stEthBtcRetrieved;
+
+    // Attempt to get the Fallback's stETH/BTC price
+    try fallbackCaller.getFallbackResponse() returns (
+      uint256 answer,
+      uint256 timestampRetrieved,
+      bool success
+    ) {
+      fallbackResponse.answer = answer;
+      fallbackResponse.timestamp = timestampRetrieved;
+      fallbackResponse.success = success;
+    } catch {
+      return (fallbackResponse);
+    }
+    return (fallbackResponse);
+  }
+}

--- a/great_ape_safe/ape_api/ebtc.py
+++ b/great_ape_safe/ape_api/ebtc.py
@@ -1432,8 +1432,8 @@ class eBTC:
         cdp_id_debt, cdp_id_coll = self.cdp_manager.getSyncedDebtAndCollShares(cdp_id)
         self._assert_debt_balance(cdp_id_debt)
 
-        # cached prev collateral balance
-        collateral_balance_before = self.collateral.balanceOf(self.safe.address)
+        # cached prev collateral shares
+        collateral_shares_before = self.collateral.sharesOf(self.safe.address)
 
         # 1. close target cdp id
         self.borrower_operations.closeCdp(cdp_id)
@@ -1447,9 +1447,7 @@ class eBTC:
 
         # 2.2. verify that enough collateral was returned + gas stipend, assertion denominated in common `shares` unit
         assert self.collateral.sharesOf(self.safe.address) == (
-            cdp_id_coll
-            + cdp_id_liquidator_reward_shares
-            + self.collateral.getSharesByPooledEth(collateral_balance_before)
+            cdp_id_coll + cdp_id_liquidator_reward_shares + collateral_shares_before
         )
 
         # 2.3. verify expected values are 0 at readings from the cdp manager

--- a/interfaces/helpers/IMintableERC20.sol
+++ b/interfaces/helpers/IMintableERC20.sol
@@ -9,84 +9,99 @@ pragma solidity 0.8.17;
  * @dev Interface of the ERC20 standard as defined in the EIP.
  */
 interface IMintableERC20 {
-    /**
-     * @dev Returns the amount of tokens in existence.
-     */
-    function totalSupply() external view returns (uint256);
+  /**
+   * @dev Returns the amount of tokens in existence.
+   */
+  function totalSupply() external view returns (uint256);
 
-    /**
-     * @dev Returns the amount of tokens owned by `account`.
-     */
-    function balanceOf(address account) external view returns (uint256);
+  /**
+   * @dev Returns the amount of tokens owned by `account`.
+   */
+  function balanceOf(address account) external view returns (uint256);
 
-    /**
-     * @dev Moves `amount` tokens from the caller's account to `recipient`.
-     *
-     * Returns a boolean value indicating whether the operation succeeded.
-     *
-     * Emits a {Transfer} event.
-     */
-    function transfer(address recipient, uint256 amount) external returns (bool);
+  /**
+   * @dev Moves `amount` tokens from the caller's account to `recipient`.
+   *
+   * Returns a boolean value indicating whether the operation succeeded.
+   *
+   * Emits a {Transfer} event.
+   */
+  function transfer(address recipient, uint256 amount) external returns (bool);
 
-    /**
-     * @dev Returns the remaining number of tokens that `spender` will be
-     * allowed to spend on behalf of `owner` through {transferFrom}. This is
-     * zero by default.
-     *
-     * This value changes when {approve} or {transferFrom} are called.
-     */
-    function allowance(address owner, address spender) external view returns (uint256);
+  /**
+   * @dev Returns the remaining number of tokens that `spender` will be
+   * allowed to spend on behalf of `owner` through {transferFrom}. This is
+   * zero by default.
+   *
+   * This value changes when {approve} or {transferFrom} are called.
+   */
+  function allowance(
+    address owner,
+    address spender
+  ) external view returns (uint256);
 
-    function increaseAllowance(address spender, uint256 addedValue) external returns (bool);
+  function increaseAllowance(
+    address spender,
+    uint256 addedValue
+  ) external returns (bool);
 
-    function decreaseAllowance(address spender, uint256 subtractedValue) external returns (bool);
+  function decreaseAllowance(
+    address spender,
+    uint256 subtractedValue
+  ) external returns (bool);
 
-    /**
-     * @dev Sets `amount` as the allowance of `spender` over the caller's tokens.
-     *
-     * Returns a boolean value indicating whether the operation succeeded.
-     *
-     * IMPORTANT: Beware that changing an allowance with this method brings the risk
-     * that someone may use both the old and the new allowance by unfortunate
-     * transaction ordering. One possible solution to mitigate this race
-     * condition is to first reduce the spender's allowance to 0 and set the
-     * desired value afterwards:
-     * https://github.com/ethereum/EIPs/issues/20#issuecomment-263524729
-     *
-     * Emits an {Approval} event.
-     */
-    function approve(address spender, uint256 amount) external returns (bool);
+  /**
+   * @dev Sets `amount` as the allowance of `spender` over the caller's tokens.
+   *
+   * Returns a boolean value indicating whether the operation succeeded.
+   *
+   * IMPORTANT: Beware that changing an allowance with this method brings the risk
+   * that someone may use both the old and the new allowance by unfortunate
+   * transaction ordering. One possible solution to mitigate this race
+   * condition is to first reduce the spender's allowance to 0 and set the
+   * desired value afterwards:
+   * https://github.com/ethereum/EIPs/issues/20#issuecomment-263524729
+   *
+   * Emits an {Approval} event.
+   */
+  function approve(address spender, uint256 amount) external returns (bool);
 
-    /**
-     * @dev Moves `amount` tokens from `sender` to `recipient` using the
-     * allowance mechanism. `amount` is then deducted from the caller's
-     * allowance.
-     *
-     * Returns a boolean value indicating whether the operation succeeded.
-     *
-     * Emits a {Transfer} event.
-     */
-    function transferFrom(address sender, address recipient, uint256 amount) external returns (bool);
+  /**
+   * @dev Moves `amount` tokens from `sender` to `recipient` using the
+   * allowance mechanism. `amount` is then deducted from the caller's
+   * allowance.
+   *
+   * Returns a boolean value indicating whether the operation succeeded.
+   *
+   * Emits a {Transfer} event.
+   */
+  function transferFrom(
+    address sender,
+    address recipient,
+    uint256 amount
+  ) external returns (bool);
 
-    function name() external view returns (string memory);
+  function name() external view returns (string memory);
 
-    function mint(address account, uint256 amount) external; 
+  function mint(address account, uint256 amount) external;
 
-    function symbol() external view returns (string memory);
+  function symbol() external view returns (string memory);
 
-    function decimals() external view returns (uint8);
+  function decimals() external view returns (uint8);
 
-    /**
-     * @dev Emitted when `value` tokens are moved from one account (`from`) to
-     * another (`to`).
-     *
-     * Note that `value` may be zero.
-     */
-    event Transfer(address indexed from, address indexed to, uint256 value);
+  function owner() external view returns (address);
 
-    /**
-     * @dev Emitted when the allowance of a `spender` for an `owner` is set by
-     * a call to {approve}. `value` is the new allowance.
-     */
-    event Approval(address indexed owner, address indexed spender, uint256 value);
+  /**
+   * @dev Emitted when `value` tokens are moved from one account (`from`) to
+   * another (`to`).
+   *
+   * Note that `value` may be zero.
+   */
+  event Transfer(address indexed from, address indexed to, uint256 value);
+
+  /**
+   * @dev Emitted when the allowance of a `spender` for an `owner` is set by
+   * a call to {approve}. `value` is the new allowance.
+   */
+  event Approval(address indexed owner, address indexed spender, uint256 value);
 }

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -35,6 +35,28 @@ def fee_recipient():
 
 
 @pytest.fixture
+def canceller(security_multisig):
+    security_multisig.init_ebtc()
+    lowsec_timelock = security_multisig.ebtc.lowsec_timelock
+    highsec_timelock = security_multisig.ebtc.highsec_timelock
+
+    # Grant CANCELLER_ROLE to account on both timelocks
+    role = lowsec_timelock.CANCELLER_ROLE()
+    canceller = accounts[8].address
+    lowsec_timelock.grantRole(
+        role,
+        canceller,
+        {"from": accounts.at(lowsec_timelock.address, force=True)},
+    )
+    highsec_timelock.grantRole(
+        role,
+        canceller,
+        {"from": accounts.at(highsec_timelock.address, force=True)},
+    )
+    return GreatApeSafe(canceller)
+
+
+@pytest.fixture
 def wbtc(security_multisig):
     wbtc = interface.IMintableERC20(registry.eth.assets.wbtc)
     owner = accounts.at(wbtc.owner(), force=True)

--- a/tests/ebtc/test_cdp_ops.py
+++ b/tests/ebtc/test_cdp_ops.py
@@ -5,16 +5,12 @@ def test_cdp_open_happy(random_safe, setup_test_coll):
     coll_amount = 5e18
     random_safe.init_ebtc()
 
-    random_safe.ebtc.collateral.forceDeposit(coll_amount)
-
     random_safe.ebtc.open_cdp(coll_amount, 160e16)
 
 
-def test_cdp_close_happy(random_safe, setup_test_coll):
+def test_cdp_close_happy(random_safe, setup_test_coll, setup_base_cdp):
     coll_amount = 5e18
     random_safe.init_ebtc()
-
-    random_safe.ebtc.collateral.forceDeposit(coll_amount)
 
     cdp_id = random_safe.ebtc.open_cdp(coll_amount, 160e16)
 
@@ -25,8 +21,6 @@ def test_cdp_add_collateral_happy(random_safe, setup_test_coll):
     coll_amount = 5e18
     random_safe.init_ebtc()
 
-    random_safe.ebtc.collateral.forceDeposit(coll_amount * 2)
-
     cdp_id = random_safe.ebtc.open_cdp(coll_amount, 160e16)
 
     random_safe.ebtc.cdp_add_collateral(cdp_id, coll_amount)
@@ -36,8 +30,6 @@ def test_cdp_withdraw_collateral_happy(random_safe, setup_test_coll):
     coll_amount = 5e18
     random_safe.init_ebtc()
 
-    random_safe.ebtc.collateral.forceDeposit(coll_amount)
-
     cdp_id = random_safe.ebtc.open_cdp(coll_amount, 160e16)
 
     random_safe.ebtc.cdp_withdraw_collateral(cdp_id, coll_amount / 10)
@@ -46,8 +38,6 @@ def test_cdp_withdraw_collateral_happy(random_safe, setup_test_coll):
 def test_cdp_repay_debt_happy(random_safe, setup_test_coll):
     coll_amount = 5e18
     random_safe.init_ebtc()
-
-    random_safe.ebtc.collateral.forceDeposit(coll_amount)
 
     cdp_id = random_safe.ebtc.open_cdp(coll_amount, 160e16)
 
@@ -59,8 +49,6 @@ def test_cdp_repay_debt_happy(random_safe, setup_test_coll):
 def test_cdp_withdraw_debt_happy(random_safe, setup_test_coll):
     coll_amount = 5e18
     random_safe.init_ebtc()
-
-    random_safe.ebtc.collateral.forceDeposit(coll_amount)
 
     cdp_id = random_safe.ebtc.open_cdp(coll_amount, 160e16)
 

--- a/tests/ebtc/test_governance_operations.py
+++ b/tests/ebtc/test_governance_operations.py
@@ -153,16 +153,15 @@ def test_cdpManager_set_grace_period_checks(techops):
 def test_priceFeed_set_fallback_caller_happy(techops, mock_fallback_caller):
     techops.init_ebtc()
 
-    ## Setup mock fallback caller with current price
-    current_price = techops.ebtc.ebtc_feed.lastGoodPrice()
-    current_time = chain.time()
-    mock_fallback_caller.setFallbackResponse(
-        current_price, current_time, True, {"from": techops.account}
-    )
     techops.ebtc.priceFeed_set_fallback_caller(mock_fallback_caller)
 
     chain.sleep(techops.ebtc.lowsec_timelock.getMinDelay() + 1)
     chain.mine()
+
+    price = techops.ebtc.ebtc_feed.fetchPrice.call()
+    mock_fallback_caller.setFallbackResponse(
+        price, chain.time(), True, {"from": techops.account}
+    )
 
     techops.ebtc.priceFeed_set_fallback_caller(mock_fallback_caller)
 
@@ -340,7 +339,7 @@ def test_activePool_sweep_token_happy(fee_recipient, wbtc, security_multisig):
     recipient = fee_recipient.ebtc.active_pool.feeRecipientAddress()
     amount = 500 * 10 ** wbtc.decimals()
 
-    wbtc.mint(
+    wbtc.transfer(
         fee_recipient.ebtc.active_pool.address,
         amount,
         {"from": security_multisig.account},
@@ -358,7 +357,7 @@ def test_activePool_sweep_token_permissions(wbtc, security_multisig, random_safe
     active_pool = random_safe.ebtc.active_pool.address
     amount = 500 * 10 ** wbtc.decimals()
 
-    wbtc.mint(
+    wbtc.transfer(
         random_safe.ebtc.active_pool.address,
         amount,
         {"from": security_multisig.account},
@@ -377,7 +376,7 @@ def test_collSurplusPool_sweep_token_happy(fee_recipient, wbtc, security_multisi
     recipient = fee_recipient.ebtc.coll_surplus_pool.feeRecipientAddress()
     amount = 500 * 10 ** wbtc.decimals()
 
-    wbtc.mint(
+    wbtc.transfer(
         fee_recipient.ebtc.coll_surplus_pool.address,
         amount,
         {"from": security_multisig.account},
@@ -395,7 +394,7 @@ def test_collSurplusPool_sweep_token_permissions(wbtc, security_multisig, random
     coll_surplus_pool = random_safe.ebtc.coll_surplus_pool.address
     amount = 500 * 10 ** wbtc.decimals()
 
-    wbtc.mint(
+    wbtc.transfer(
         random_safe.ebtc.coll_surplus_pool.address,
         amount,
         {"from": security_multisig.account},

--- a/tests/ebtc/test_timelock_tx_helpers.py
+++ b/tests/ebtc/test_timelock_tx_helpers.py
@@ -66,9 +66,9 @@ def test_execute_timelock_permissions_on_target(techops):
         )
 
 
-def test_cancel_timelock_before_scheduling(techops, security_multisig, random_safe):
+def test_cancel_timelock_before_scheduling(techops, canceller):
     techops.init_ebtc()
-    security_multisig.init_ebtc()
+    canceller.init_ebtc()
 
     target = techops.ebtc.active_pool
     data = target.setFeeBps.encode_input(100)
@@ -78,12 +78,11 @@ def test_cancel_timelock_before_scheduling(techops, security_multisig, random_sa
 
     ## Attempts to cancel the operation before scheduled
     with pytest.raises(Exception, match="Error: operation does not exist"):
-        security_multisig.ebtc.cancel_lowsec_timelock(id)
+        canceller.ebtc.cancel_lowsec_timelock(id)
 
 
-def test_cancel_timelock_permissions(techops, security_multisig, random_safe):
+def test_cancel_timelock_permissions(techops, random_safe):
     techops.init_ebtc()
-    security_multisig.init_ebtc()
     random_safe.init_ebtc()
 
     target = techops.ebtc.active_pool
@@ -103,9 +102,9 @@ def test_cancel_timelock_permissions(techops, security_multisig, random_safe):
         random_safe.ebtc.cancel_lowsec_timelock(id)
 
 
-def test_cancel_pending_operation(techops, security_multisig):
+def test_cancel_pending_operation(techops, canceller):
     techops.init_ebtc()
-    security_multisig.init_ebtc()
+    canceller.init_ebtc()
 
     target = techops.ebtc.active_pool
     data = target.setFeeBps.encode_input(100)
@@ -126,14 +125,14 @@ def test_cancel_pending_operation(techops, security_multisig):
     assert techops.ebtc.lowsec_timelock.isOperationPending(id)
 
     ## Permissioned account can cancel pending operation
-    security_multisig.ebtc.cancel_lowsec_timelock(id)
+    canceller.ebtc.cancel_lowsec_timelock(id)
 
     assert techops.ebtc.lowsec_timelock.isOperationPending(id) == False
 
 
-def test_cancel_ready_operation(techops, security_multisig):
+def test_cancel_ready_operation(techops, canceller):
     techops.init_ebtc()
-    security_multisig.init_ebtc()
+    canceller.init_ebtc()
 
     target = techops.ebtc.active_pool
     data = target.setFeeBps.encode_input(100)
@@ -154,14 +153,14 @@ def test_cancel_ready_operation(techops, security_multisig):
     assert techops.ebtc.lowsec_timelock.isOperationReady(id)
 
     ## Permissioned account can cancel ready operation
-    security_multisig.ebtc.cancel_lowsec_timelock(id)
+    canceller.ebtc.cancel_lowsec_timelock(id)
 
     assert techops.ebtc.lowsec_timelock.isOperationReady(id) == False
 
 
-def test_cancel_operation_from_parameters(techops, security_multisig):
+def test_cancel_operation_from_parameters(techops, canceller):
     techops.init_ebtc()
-    security_multisig.init_ebtc()
+    canceller.init_ebtc()
 
     target = techops.ebtc.active_pool
     data = target.setFeeBps.encode_input(100)
@@ -182,7 +181,7 @@ def test_cancel_operation_from_parameters(techops, security_multisig):
     assert techops.ebtc.lowsec_timelock.isOperationReady(id)
 
     ## Permissioned account can cancel ready operation
-    security_multisig.ebtc.cancel_lowsec_timelock(
+    canceller.ebtc.cancel_lowsec_timelock(
         "0x0", target.address, 0, data, EmptyBytes32, EmptyBytes32
     )
 


### PR DESCRIPTION
Adapted all tests to work for mainnet fork (previously eBTC tests were pointing at Sepolia addresses). Flattened mock contracts were added to the project and deployed within the fixtures, asset funding introduced from mainnet setup. Only a small logic adjustment introduced to the close_cdp function on the balance check (statndardized checks in terms of shares).

Run tests with:
```
brownie test
```

Results:
![image](https://github.com/ebtc-protocol/ebtc-multisig/assets/25463788/8fb54e54-74b0-482e-bec1-f60d6ed02c8a)
 