### PR TITLE
feat: steps towards atomic swap and campaign

### DIFF
--- a/scripts/merkl_incentive_campaign.py
+++ b/scripts/merkl_incentive_campaign.py
@@ -230,8 +230,8 @@ def create_campaign(
         safe.post_safe_tx()
 
 
-def swap_badger_for_campaign_target(ebtc_vault_owned=0):
-    safe.init_cow(prod=True)
+def swap_badger_for_campaign_target(ebtc_vault_owned=22.1513):
+    safe.init_uni_v3()
     safe.init_ebtc()
 
     # tokens
@@ -273,10 +273,10 @@ def swap_badger_for_campaign_target(ebtc_vault_owned=0):
         f"[green]swapping {weth_equivalent_mantissa / (10 ** weth.decimals())} $weth for $badger\n[/green]"
     )
 
-    # cow order
-    safe.cow.market_sell(
-        weth, badger, weth_equivalent_mantissa, deadline=DEADLINE, coef=COEF
-    )
+    # univ3 swap
+    wbtc_amount_out = safe.uni_v3.swap([weth, wbtc], weth_equivalent_mantissa)
+    # @note divide in two swaps to debug the wbtc -> badger hop as it is reverting with `revert: TF`
+    badger_amount_out = safe.uni_v3.swap([wbtc, badger], wbtc_amount_out)
 
     safe.post_safe_tx()
 


### PR DESCRIPTION
currently there is a hop that will happen in univ3 given a revert locally, which ill like to confirm that others are able to replicate as well locally

run:

```
brownie run scripts/merkl_incentive_campaign swap_badger_for_campaign_target
```

simulation of each `self.quoter.quoteExactInput.call` in isolation:

- [(Weth -> wbtc)](https://dashboard.tenderly.co/testing-ape/project/simulator/7841b822-7915-4dab-9762-b9f323829d13)
- [(wbtc-> badger)](https://dashboard.tenderly.co/testing-ape/project/simulator/b07b0d88-21e8-4cee-8498-b21d72ca2f11) 